### PR TITLE
README.md - renderers table - OpenGL columns to be next to each other

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ SoftGPU can use 4 render drivers:
 Not all renderers supporting all application/games, performance expectation is in 1024x768 32bit:
 
 
-| Renderer            | Requirements   | OpenGL version | DX9  | DX9 shaders | DX8  | DX8 shaders | DX6-7 | OpenGL | multiple contexts | window mode | Glide | Glide DOS | Expected FPS |
-| :------------------ | :------------: | :------------: | :--: | :---------: | :--: | :---------: | :---: | :----: | :---------------: | :---------: | :---: | :-------: | :----------: |
-| softpipe            |      -         |     3.3        |  ✔  |      ✔     |  ✔  |      ✔     |  ✔   |   ✔   |  ✔               |  ✔         |  ✔   |    ❌     |    1-3       |
-| llvmlipe (128 bits) |     SSE        |     3.3        |  ✔  |      ✔     |  ✔  |      ✔     |  ✔   |   ✔   |  ✔               |  ✔         |  ✔   |    ❌     |    10-15     |
-| llvmlipe (256 bits) |   SSE, AVX     |     3.3        |  ✔  |      ✔     |  ✔  |      ✔     |  ✔   |   ✔   |  ✔               |  ✔         |  ✔   |    ❌     |    12-20     |
-| SVGA3D              | SVGA-II (gen9) |     2.1        |  ✔  |      ❌     |  ✔  |      ❌     |  ✔   |   ✔   |  ⚠               |  ✔         |  ✔   |    ❌     |    30-60     |
-| SVGA3D              | SVGA-II (gen10)|     4.1        |  ✔  |      ✔     |  ✔  |      ✔     |  ✔   |   ✔   |  ✔               |  ✔         |  ✔   |    ❌     |    35-80     |
-| qemu-3dfx           | [qemu-3dfx](https://github.com/kjliew/qemu-3dfx) |     native        |  ✔  |      ✔     |  ✔               |  ✔         |   ✔  |      ✔     |  ❌   |   ❌   |  ✔ *   |    ✔ *     |    native/2 *  |
+| Renderer            | Guest Requirements   | DX9  | DX9 shaders | DX8  | DX8 shaders | DX6-7 | OpenGL | OpenGL version | multiple contexts | window mode | Glide | Glide DOS | Expected FPS |
+| :------------------ | :------------: | :--: | :---------: | :--: | :---------: | :---: | :----: | :------------: | :---------------: | :---------: | :---: | :-------: | :----------: |
+| softpipe            |      -         |  ✔  |      ✔     |  ✔  |      ✔     |  ✔   |   ✔   |     3.3        |  ✔               |  ✔         |  ✔   |    ❌     |    1-3       |
+| llvmlipe (128 bits) |     SSE        |  ✔  |      ✔     |  ✔  |      ✔     |  ✔   |   ✔   |     3.3        |  ✔               |  ✔         |  ✔   |    ❌     |    10-15     |
+| llvmlipe (256 bits) |   SSE, AVX     |  ✔  |      ✔     |  ✔  |      ✔     |  ✔   |   ✔   |     3.3        |  ✔               |  ✔         |  ✔   |    ❌     |    12-20     |
+| SVGA3D              | SVGA-II (gen9) |  ✔  |      ❌     |  ✔  |      ❌     |  ✔   |   ✔   |     2.1        |  ⚠               |  ✔         |  ✔   |    ❌     |    30-60     |
+| SVGA3D              | SVGA-II (gen10)|  ✔  |      ✔     |  ✔  |      ✔     |  ✔   |   ✔   |     4.1        |  ✔               |  ✔         |  ✔   |    ❌     |    35-80     |
+| qemu-3dfx           | [qemu-3dfx](https://github.com/kjliew/qemu-3dfx) |  ✔  |      ✔     |  ✔               |  ✔         |   ✔  |      ✔     |     native        |  ❌   |   ❌   |  ✔ *   |    ✔ *     |    native/2 *  |
 
-Note for qemu-3dfx: performance depends on CPU emulation - you can reach about 1/2 of native GPU performance when using KVM acceleration on x86-64 host, about 1/5 when using Hyper-V, and about from 1/100 when is using accelerated emulation and about 1/1000 when using full emulation. DOS Glide and *native* Glide wrapper isn't part of SoftGPU. You have to compile it from source or you can [donate qemu-3dfx author](https://github.com/kjliew/qemu-3dfx#donation).
+(*) Note for qemu-3dfx: performance depends on CPU emulation - you can reach about 1/2 of native GPU performance when using KVM acceleration on x86-64 host, about 1/5 when using Hyper-V, and about from 1/100 when is using accelerated emulation and about 1/1000 when using full emulation. DOS Glide and *native* Glide wrapper isn't part of SoftGPU. You have to compile it from source or you can [donate qemu-3dfx author](https://github.com/kjliew/qemu-3dfx#donation).
 
 
 Hypervisor translation to real HW GPU:


### PR DESCRIPTION
Moved OpenGL version next to the OpenGL column.
Clarified requirements column is for the Guest side. 
Added asterisk to "Note".

Further questions:
- Maybe just merge the OpenGL columns? e.g. if some OpenGL version is supported, then obviously OpenGL itself is supported
- The FPS column is very handy in illustrating what performance to expect. Can you share for what host CPU/GPU are those numbers? I assume CPU is relevant for softpipe/llvmlipe, GPU for SVGA3D.
- "Note for qemu-3dfx: performance depends on CPU emulation" - gives GPU host/guest performance ratios for KVM, Hyper-V, TCG accelerated, TCG full. But does it also matter how fast the host CPU is? E.g. I assume there's some lower boundary (e.g. a Pentium III host won't be very useful), but more importantly - are faster modern CPUs helping with performance or above certain level of host CPU the performance is flat?
- why llvmlipe stops at OpenGL 3.3? Mesamatrix [shows 4.6](https://mesamatrix.net/#OpenGL)
- <s>why SVGA-II gen10 stops at OpenGL 4.1?</s> clear, that's the [maximum provided by VirtualBox](https://www.virtualbox.org/wiki/Changelog-7.0#v10)